### PR TITLE
Call resume on the context to cope with the latest Chrome Android changes

### DIFF
--- a/src/app/engine/beat-engine.service.ts
+++ b/src/app/engine/beat-engine.service.ts
@@ -65,6 +65,7 @@ export class BeatEngineService {
   }
 
   public start() {
+    this.mixer.context.resume();
     this.scheduleBuffers();
     this.zone.runOutsideAngular(() => {
       this.beatTick();


### PR DESCRIPTION
if someone tries to use the website from an Android, with the latest version of Chrome, or Android browser, the AudioContext gets created as "suspended", to allow it to play we need to call resume() on it.

