### PR TITLE
fix: App crashes on Safari and iOS devices

### DIFF
--- a/src/app/engine/audio-backend.service.ts
+++ b/src/app/engine/audio-backend.service.ts
@@ -110,13 +110,19 @@ export class AudioBackendService {
   }
 
   private loadBank(url: string) {
+    // on Safari we need to use callbacks using decodeAudioData method.
     this.http
       .get(url, { responseType: 'arraybuffer' })
-      .pipe(mergeMap((result) => this.context.decodeAudioData(result)))
-      .subscribe((buffer) => {
-        this.buffer = buffer;
+      .pipe(mergeMap((result) => new Promise((resolve, reject) => {
+        this.context.decodeAudioData(result, resolve, reject)
+      })))
+      .subscribe(
+        (buffer) => {
+        this.buffer = buffer as any;
         this.ready = true;
-      });
+        },
+        err => console.log(`Error loading bank: ${err}`)
+      );
   }
 
   private loadBankDescriptor(url: string) {

--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -66,3 +66,6 @@ import 'zone.js/dist/zone';  // Included with Angular CLI.
  * Needed for: All but Chrome, Firefox, Edge, IE11 and Safari 10
  */
 // import 'intl';  // Run `npm install --save intl`.
+
+// AudioContext polyfill needed on Safari
+(window as any).AudioContext = (window as any).AudioContext || (window as any).webkitAudioContext;


### PR DESCRIPTION
fix: Added AudioContext polyfill(Safari), and on loadBank() a callback replaces the observable to give Safari support when using decodeAudioData method

- Problem: App crashed on Safari browser and iOS devices
- Tested: on Safari browser(OK), must be tested also on iPhone and iPad devices

* This PR adds the prefix `webkit` to `AudioContext` when needed (ie: Safari)

* This PR replace the Observable used on `loadBank` method for a Callback system, it works also in Chrome... and this callback is needed to work on Safari (Desktop & iOS(to test))
