### PR TITLE
Fix: App now is working on iOS devices

### DIFF
--- a/src/app/engine/audio-backend.service.ts
+++ b/src/app/engine/audio-backend.service.ts
@@ -96,8 +96,13 @@ export class AudioBackendService {
 
   constructor(private http: HttpClient) {
     this.ready = false;
-    const hasWebM = MediaSource && MediaSource.isTypeSupported('audio/webm;codecs="vorbis"');
-    this.loadBank(hasWebM ? 'assets/audio/main.webm' : 'assets/audio/main.mp3');
+    const isIOS = /iPad|iPhone|iPod/.test(navigator.userAgent) && !(window as any).MSStream;
+    let hasWebM;
+    // MediaSource is not supported on iOS
+    if (!isIOS) {
+      hasWebM = MediaSource && MediaSource.isTypeSupported('audio/webm;codecs="vorbis"');
+    }
+    this.loadBank(hasWebM && !isIOS ? 'assets/audio/main.webm' : 'assets/audio/main.mp3');
     this.loadBankDescriptor('assets/audio/main.json');
   }
 


### PR DESCRIPTION
Using MediaSource made crash the app on iOS devices, as you can see: https://developer.mozilla.org/en-US/docs/Web/API/MediaSource  
iOS doesn't support it
I added a condition to test if we're in a iOS environnement, if yes we won't use MediaSource